### PR TITLE
Add composer details

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,18 @@
 {
+    "name": "flynsarmy/oc-idehelper-plugin",
+    "type": "october-plugin",
+    "description": "OctoberCMS plugin to make development easier by providing IDE helpers",
+    "homepage": "https://github.com/Flynsarmy/oc-idehelper-plugin",
+    "keywords": ["october", "octobercms", "laravel", "ide", "helper", "vscode", "phpstorm", "php"],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Flynsarmy",
+            "homepage": "https://www.flynsarmy.com/"
+        }
+    ],
     "require": {
+        "composer/installers": "~1.0",
         "barryvdh/laravel-ide-helper": "2.4.1"
     }
 }


### PR DESCRIPTION
Adds details to composer.json so this plugin can be listed on Packagist. After merging this in, please create an account on Packagist and list the plugin so that developers can install it via composer.