### PR TITLE
Add setting write_model_magic_where

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -101,4 +101,13 @@ return array(
     */
     'custom_db_types' => array(
     ),
+    /*
+    |--------------------------------------------------------------------------
+    | Write Model Magic methods
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable write magic methods of model
+    |
+    */
+    'write_model_magic_where' => true,
 );


### PR DESCRIPTION
**write_model_magic_where** to write magic methods of model like

```
* @method static \Illuminate\Database\Eloquent\Builder|\October\Test\Models\Meta whereId($value)
```
If you have a lot of properties it could be useful to set it to false to reduce the number of lines