### PR TITLE
Fix error in laravel 6.X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "composer/installers": "~1.0",
-        "barryvdh/laravel-ide-helper": "^2.7.0"
+        "barryvdh/laravel-ide-helper": "~2.7.0"
     }
 }


### PR DESCRIPTION
Currently octobercms 1.1.x supports since laravel 6.x LTS. However, since barryvdh/laravel-ide-helper 2.8.x only supports laravel 8.x upwards, causing an error to appear when executing php artisan ide-helper:generate under laravel 6.x.

The update setting ~2.7.0 will ensure that laravel-ide-helper runs from laravel 6.x up to 8.x without any problems.